### PR TITLE
chore: GitHub Pages 배포 설정 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build

--- a/config/index.ts
+++ b/config/index.ts
@@ -9,7 +9,7 @@ const config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   favicon: "/img/favicon.ico",
-  organizationName: "bcsd", // Usually your GitHub org/user name.
+  organizationName: "BCSDLab", // Usually your GitHub org/user name.
   projectName: "BCSD-Blog", // Usually your repo name.
   presets: [
     [
@@ -18,10 +18,10 @@ const config = {
         blog: {
           showReadingTime: true,
           feedOptions: {
-            type: 'rss',
+            type: "rss",
             copyright: `Copyright © ${new Date().getFullYear()} BCSD. All rights reserved.`,
             createFeedItems: async (params) => {
-              const {blogPosts, defaultCreateFeedItems, ...rest} = params;
+              const { blogPosts, defaultCreateFeedItems, ...rest } = params;
               return defaultCreateFeedItems({
                 blogPosts: blogPosts,
                 ...rest,
@@ -43,11 +43,11 @@ const config = {
   themeConfig: {
     ...themeConfig,
     metadata: [
-      {name: 'keyword', content: 'BCSD, Blog'},
-      {name: 'author', content: 'BCSD'},
-      {name: 'description', content: 'BCSD 전용 블로그입니다.'},
-    ]
-  }
+      { name: "keyword", content: "BCSD, Blog" },
+      { name: "author", content: "BCSD" },
+      { name: "description", content: "BCSD 전용 블로그입니다." },
+    ],
+  },
 };
 
 module.exports = config;

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+blog.bcsdlab.com


### PR DESCRIPTION
## Summary

- `static/CNAME` 추가 — `blog.bcsdlab.com` 커스텀 도메인 유지
- `.github/workflows/deploy.yml` 추가 — `main` 브랜치 push 시 자동 빌드 & `gh-pages` 브랜치로 배포
- `config/index.ts` `organizationName` 수정 (`bcsd` → `BCSDLab`)

## 추가로 필요한 작업

1. GitHub repo **Settings → Pages → Source**를 `gh-pages` 브랜치로 변경
2. DNS A 레코드를 GitHub Pages IP로 변경 (`185.199.108~111.153`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Set up continuous deployment pipeline enabling automatic building and publishing to GitHub Pages when changes are pushed to the main branch.
  * Updated organization branding in project configuration.
  * Configured custom domain routing for the blog platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->